### PR TITLE
Fix: Update download source and add retry logic for accessibility data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: AccessUK
-Title: AccessUK: Accessibility measures for the UK.
-Version: 0.0.0.9002
+Title: Accessibility Measures for the UK
+Version: 0.0.0.9003
 Authors@R: 
     person("Rafael", "Verduzco-Torres", , "JoseRafaelVerduzco-Torres@glasgow.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1324-1714"))
 Description: A package to retrieve ready-to-use and tailor accessibility measures in the UK.
-    See the paper (...) <doi:xxx> for more information.
+    See Verduzco-Torres and McArthur (2025) <doi:10.1038/s41597-023-02890-w> for methodological details.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/download_accessibility_data.R
+++ b/R/download_accessibility_data.R
@@ -1,101 +1,125 @@
-
 #' Download and extract Accessibility Indicators Dataset for GB
 #'
-#' Downloads the accessibility indicators dataset for Great Britain from Zenodo.
-#' If Zenodo download fails or is too slow, falls back to an alternative URL.
+#' Downloads the accessibility indicators dataset for Great Britain from Cloudflare R2.
+#' Includes retry logic to handle temporary network issues.
 #'
-#' @param force_update Logical; re-download even if data exists.
-#' @param data_dir Directory where data should be stored.
-#' @param quiet Logical; suppress messages when TRUE.
-#' @param timeout Numeric; total timeout per attempt in seconds (default 3600).
-#' @param low_speed_limit Numeric; abort if speed < this (Mb/sec) for low_speed_time (default 512 bytes/sec).
-#' @param low_speed_time Numeric; duration in seconds to trigger low-speed abort (default 120).
-#' @param max_attempts Integer; number of attempts per source (default 2).
+#' @param force_update Logical; if TRUE, re-download even if data exists. Default is FALSE.
+#' @param data_dir Character; directory where data should be stored.
+#'   Default is the package installation directory.
+#' @param max_download_attempts Integer; number of download attempts before failing.
+#'   Default is 2.
+#' @param max_timeout Numeric; maximum timeout in seconds for the download.
+#'   Default is 900 (15 min).
+#' @param quiet Logical; if TRUE, suppress progress messages. Default is FALSE.
 #'
-#' @return Path to the extracted data directory invisibly.
+#' @return Path to the extracted data directory (invisibly).
 #' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Download data (uses cache if already exists)
+#' download_accessibility_data()
+#'
+#' # Force re-download
+#' download_accessibility_data(force_update = TRUE)
+#' }
 download_accessibility_data <- function(
     force_update = FALSE,
     data_dir = system.file(package = "AccessUK"),
-    quiet = FALSE,
-    timeout = 3600,
-    low_speed_limit = 5,   # 5 MB/s
-    low_speed_time = 120,    # 2 minutes
-    max_attempts = 2
+    max_download_attempts = 2L,
+    max_timeout = 900,
+    quiet = FALSE
 ) {
-  # Validate inputs
-  checkmate::assert_logical(force_update)
-  checkmate::assert_logical(quiet)
-  checkmate::assert_number(timeout, lower = 30)
-  checkmate::assert_number(low_speed_limit, lower = 1)
-  checkmate::assert_number(low_speed_time, lower = 10)
-  checkmate::assert_int(max_attempts, lower = 1)
+  # Check input
+  checkmate::assert_logical(force_update, len = 1)
+  checkmate::assert_logical(quiet, len = 1)
+  checkmate::assert_int(max_download_attempts, lower = 1)
+  checkmate::assert_number(max_timeout, lower = 30)
 
-  # Set timeout globally
+  # Update timeout option temporarily
   old_options <- options()
   on.exit(options(old_options), add = TRUE)
-  options(timeout = max(timeout, getOption("timeout")))
+  options(timeout = max(max_timeout, getOption("timeout")))
 
-  # Prepare directories
-  data_dir <- file.path(data_dir, "data")
-  if (!dir.exists(data_dir)) dir.create(data_dir, recursive = TRUE)
+  # Out directory
+  data_dir <- file.path(data_dir, 'data')
 
-  accessibility_dir <- file.path(data_dir, "accessibility_indicators_gb")
+  # Check if data directory exists, and if not, create it
+  if (!dir.exists(data_dir)) {
+    dir.create(data_dir, recursive = TRUE)
+  }
+
+  # Check if data already exists and handle force_update
+  accessibility_dir <- file.path(data_dir, 'accessibility_indicators_gb')
   if (dir.exists(accessibility_dir) && !force_update) {
     if (!quiet) message("Using cached accessibility data.")
     return(invisible(data_dir))
   }
 
-  # URLs
-  zenodo_url <- "https://zenodo.org/record/8037156/files/accessibility_indicators_gb.zip?download=1"
-  fallback_url <- "https://ubdcdcstageadmin.blob.core.windows.net/dc-os/26/open-release-ptai-2021_28062022.zip?se=2025-12-02T12%3A04%3A16Z&sp=r&sv=2025-01-05&sr=b&sig=ME4EMW4xgpz5vi5UOIMcRFlrX3/bQSYDPbFoy3EXul0%3D"
+  # Define URLs and paths
+  cloudflare_url <- "https://pub-ae0a5e06f7384f5db5345414997d9f7c.r2.dev/accessibility_indicators_gb.zip"
   zip_file <- file.path(data_dir, "accessibility_indicators_gb.zip")
 
-  # Transform MB to Kb
-  low_speed_limit <- low_speed_limit * 1024 * 1024
+  # Download the file with retry logic
+  if (!quiet) {
+    message("Downloading accessibility data.\nThis can take a few minutes the first time it is run.")
+  }
 
-  # Helper: download with retry and low-speed detection
-  download_attempt <- function(url, destfile, label) {
-    for (i in seq_len(max_attempts)) {
-      if (!quiet) message(sprintf("Downloading from %s (attempt %d)...", label, i))
-      h <- curl::new_handle()
-      curl::handle_setopt(
-        h,
-        timeout = timeout,
-        low_speed_time = low_speed_time,
-        low_speed_limit = low_speed_limit
-      )
-      ok <- TRUE
-      try({
-        curl::curl_download(url, destfile = destfile, mode = "wb", handle = h)
-      }, silent = TRUE) -> err
-      if (file.exists(destfile) && file.info(destfile)$size > 0) return(TRUE)
-      Sys.sleep(2 ^ i) # simple backoff
+  download_success <- FALSE
+
+  for (attempt in seq_len(max_download_attempts)) {
+    result <- try(
+      utils::download.file(
+        url = cloudflare_url,
+        destfile = zip_file,
+        mode = 'wb'
+      ),
+      silent = TRUE
+    )
+
+    if (!inherits(result, "try-error") && file.exists(zip_file)) {
+      download_success <- TRUE
+      break
     }
-    FALSE
+
+    if (attempt < max_download_attempts) {
+      if (!quiet) {
+        message(sprintf("Download attempt %d failed. Retrying in 2 seconds...", attempt))
+      }
+      Sys.sleep(2)
+    }
   }
 
-  # Try Zenodo first
-  if (!quiet) message("Downloading accessibility data from Zenodo...")
-  success <- download_attempt(zenodo_url, zip_file, "Zenodo")
-
-  # Fallback if Zenodo fails
-  if (!success) {
-    if (!quiet) message("Zenodo download failed or too slow. Trying alternative source...")
-    success <- download_attempt(fallback_url, zip_file, "UBDC Azure Blob")
-    if (!success) stop("Failed to download data from both sources.")
+  if (!download_success) {
+    stop(
+      "Failed to download data after ", max_download_attempts,
+      " attempts. Please check your internet connection or try again later.",
+      call. = FALSE
+    )
   }
 
-  # Unzip and clean up
+  if (!quiet) message("Download successful. Extracting data...")
+
+  # Unzip the file
   unzip(zip_file, exdir = data_dir)
+
+  # Remove the ZIP file
   file.remove(zip_file)
 
-  # Adjust headers in TTM
-  ttm_path <- list.files(data_dir, pattern = "ttm_pt", recursive = TRUE, full.names = TRUE)
+  # Adjust headers in TTM to make it compatible with new R5R output
+  ttm_path <- list.files(
+    data_dir,
+    pattern = 'ttm_pt',
+    recursive = TRUE,
+    full.names = TRUE
+  )
+
+  # New TTM headers
   new_header <- c("from_id", "to_id", "travel_time_p25", "travel_time_p50", "travel_time_p75")
+
+  # Change names
   change_csv_header(ttm_path, new_header)
 
+  # Return data dir
   invisible(data_dir)
 }
-
-


### PR DESCRIPTION
- Replace Zenodo URL with Cloudflare R2 for more reliable downloads
- Add retry logic with configurable max_download_attempts parameter
- Improve error handling with informative messages on download failure
- Add success message before extraction step
- Update function documentation with new parameters and examples